### PR TITLE
🔗 Integrate Pact Consumer Contract Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,16 @@ jobs:
       
       - name: Run tests
         run: npm test
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+          GIT_BRANCH: ${{ github.ref_name }}
+
+      - name: Publish Pact contracts to Pact Broker
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          npx @pact-foundation/pact-cli@latest broker publish ./pacts \
+            --consumer-app-version "${{ github.sha }}" \
+            --branch "${{ github.ref_name }}" \
+            --broker-base-url "${{ secrets.PACT_BROKER_BASE_URL }}" \
+            --broker-token "${{ secrets.PACT_BROKER_TOKEN }}"
+        continue-on-error: true

--- a/PACT_MIGRATION_SUMMARY.md
+++ b/PACT_MIGRATION_SUMMARY.md
@@ -1,0 +1,168 @@
+# Pact Migration Summary
+
+## ✅ Migration Complete
+
+Your Cypress test mocks have been successfully converted to generate Pact consumer contracts using `pact-js-mock`.
+
+## What Was Changed
+
+### 1. **Dependencies**
+- Added `pact-js-mock` as a dev dependency in `package.json`
+
+### 2. **Cypress Configuration**
+- **`cypress/support/component.ts`**: Added import for `pact-js-mock/lib/cypress` to register the `cy.pactIntercept()` command
+- **`cypress.config.ts`**: Registered the Pact plugin to handle lifecycle hooks automatically
+
+### 3. **Test Files**
+- **`src/App.cy.tsx`**: Replaced all 4 `cy.intercept()` calls with `cy.pactIntercept()`
+  - All existing test logic, assertions, and aliases remain unchanged
+  - Tests continue to work exactly as before
+
+### 4. **Configuration**
+- **`pact.config.json`**: Created with consumer name `shop-frontend`, Pact version 2.0.0, and output directory `./pacts`
+
+### 5. **CI/CD Pipeline**
+- **`.github/workflows/main.yml`**: Added step to publish contracts to Pact Broker after successful tests
+  - Only publishes on pushes to `main` branch
+  - Uses GitHub secrets for `PACT_BROKER_BASE_URL` and `PACT_BROKER_TOKEN`
+
+## Generated Contracts
+
+After running tests, Pact contracts are generated in the `./pacts/` directory:
+
+- **File**: `shop-frontend-order-service.json`
+- **Consumer**: `shop-frontend`
+- **Provider**: `order-service` (automatically inferred from URLs)
+- **Interactions**: 4 interactions captured:
+  1. `GET /order-service/v1/items` → 200 (with items list)
+  2. `POST /order-service/v1/purchase` → 200 (successful purchase)
+  3. `POST /order-service/v1/purchase` → 500 (error case)
+  4. `GET /order-service/v1/items` → 200 (out of stock item)
+
+## Verification
+
+✅ **Build**: Passes successfully  
+✅ **Tests**: All 5 tests pass  
+✅ **Pact Generation**: Contracts generated correctly  
+✅ **Consumer Name**: Correctly set to `shop-frontend`  
+✅ **Provider Name**: Automatically inferred as `order-service`
+
+## Next Steps
+
+### 1. **Set Up Pact Broker Secrets** (Required for CI/CD)
+
+Add the following secrets to your GitHub repository:
+
+1. Go to your repository → Settings → Secrets and variables → Actions
+2. Add the following secrets:
+   - `PACT_BROKER_BASE_URL`: Your Pact Broker URL (e.g., `https://your-broker.pactflow.io`)
+   - `PACT_BROKER_TOKEN`: Your Pact Broker authentication token
+
+### 2. **Customize Interaction Descriptions** (Optional)
+
+You can add custom descriptions and provider states to your `cy.pactIntercept()` calls:
+
+```typescript
+cy.pactIntercept(
+  'GET',
+  '/order-service/v1/items',
+  { statusCode: 200, body: [...] },
+  {
+    description: 'get all available items',
+    providerState: 'items exist in inventory',
+  }
+).as('getItems')
+```
+
+### 3. **Add Matching Rules** (Optional, for Pact V3/V4)
+
+For dynamic data, you can add matching rules:
+
+```typescript
+cy.pactIntercept(
+  'GET',
+  '/order-service/v1/items',
+  { statusCode: 200, body: [...] },
+  {
+    description: 'get all available items',
+    matchingRules: {
+      body: {
+        '$.id': { matchers: [{ match: 'type' }] },
+        '$.stockCount': { matchers: [{ match: 'type' }] },
+      },
+    },
+  }
+).as('getItems')
+```
+
+### 4. **Configure Header Filtering** (Optional)
+
+You can configure which headers to include/exclude in the plugin configuration in `cypress.config.ts`:
+
+```typescript
+return pactPlugin(on, config, {
+  consumerName: 'shop-frontend',
+  pactVersion: '2.0.0',
+  outputDir: './pacts',
+  options: {
+    headersConfig: {
+      includes: ['content-type', 'authorization'],
+      excludes: ['user-agent', 'sec-ch-ua'],
+    },
+  },
+})
+```
+
+### 5. **Publish Contracts Manually** (Optional)
+
+To publish contracts manually to Pact Broker:
+
+```bash
+npx @pact-foundation/pact-cli@latest broker publish ./pacts \
+  --consumer-app-version "$(git rev-parse HEAD)" \
+  --branch "$(git branch --show-current)" \
+  --broker-base-url "$PACT_BROKER_BASE_URL" \
+  --broker-token "$PACT_BROKER_TOKEN"
+```
+
+### 6. **Verify Contracts in Pact Broker**
+
+After publishing, verify your contracts appear in the Pact Broker:
+- Check that the consumer `shop-frontend` is registered
+- Verify all 4 interactions are present
+- Confirm the provider `order-service` relationship is established
+
+## Key Points
+
+- **Zero Breaking Changes**: All existing tests work exactly as before
+- **Automatic Lifecycle**: Pact plugin handles contract generation automatically
+- **Provider Inference**: Provider names are automatically inferred from URLs (e.g., `*/order-service/*` → `order-service`)
+- **Backward Compatible**: The `cy.pactIntercept()` API is identical to `cy.intercept()`
+- **No Boilerplate**: No need to manually create Pact instances or manage contract files
+
+## Troubleshooting
+
+### Contracts Not Generated
+
+- Ensure `pact-js-mock` is installed: `npm install`
+- Verify the import in `cypress/support/component.ts`: `import 'pact-js-mock/lib/cypress'`
+- Check that the plugin is registered in `cypress.config.ts`
+
+### Wrong Consumer Name
+
+- Verify `pact.config.json` has the correct `consumerName`
+- Check that `package.json` name matches (or override in config)
+
+### CI/CD Publishing Fails
+
+- Verify `PACT_BROKER_BASE_URL` and `PACT_BROKER_TOKEN` secrets are set
+- Check that the Pact Broker URL is accessible from GitHub Actions
+- Ensure the token has publish permissions
+
+## Documentation
+
+For more information, refer to:
+- [pact-js-mock documentation](https://github.com/pact-foundation/pact-js-mock)
+- [Pact documentation](https://docs.pact.io/)
+- [Pact Broker documentation](https://docs.pact.io/pact_broker)
+

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "cypress";
+import pactPlugin from 'pact-js-mock/lib/cypress/plugin';
 
 export default defineConfig({
   component: {
     devServer: {
       framework: "react",
       bundler: "vite",
+    },
+    setupNodeEvents(on, config) {
+      return pactPlugin(on, config);
     },
   },
 });

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -16,5 +16,8 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
+// Import pact-js-mock Cypress support
+import 'pact-js-mock/lib/cypress'
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.11.0",
+        "pact-js-mock": "^1.0.1",
         "prettier": "^3.3.3",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.11.0",
@@ -4652,6 +4653,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pact-js-mock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pact-js-mock/-/pact-js-mock-1.0.1.tgz",
+      "integrity": "sha512-qgsHpULX4dRpdk+o1YmIIP2PuRVxwWWWU7vq3oAVJOammrT5b9rFHL4Ev/Feh6UOML3PEF4RF/DiroEqBFvY7w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/parent-module": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
+    "pact-js-mock": "^1.0.1",
     "prettier": "^3.3.3",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",

--- a/pact.config.json
+++ b/pact.config.json
@@ -1,0 +1,6 @@
+{
+  "consumerName": "shop-frontend",
+  "pactVersion": "2.0.0",
+  "outputDir": "./pacts"
+}
+

--- a/pacts/shop-frontend-order-service.json
+++ b/pacts/shop-frontend-order-service.json
@@ -1,0 +1,161 @@
+{
+  "consumer": {
+    "name": "shop-frontend"
+  },
+  "provider": {
+    "name": "order-service"
+  },
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    },
+    "client": {
+      "name": "pact-js-mock",
+      "version": "1.0.1"
+    }
+  },
+  "interactions": [
+    {
+      "description": "GET /order-service/v1/items returns status 200",
+      "response": {
+        "status": 200,
+        "body": [
+          {
+            "id": 1,
+            "name": "Test Item 1",
+            "description": "This is a test item",
+            "stockCount": 5
+          },
+          {
+            "id": 2,
+            "name": "Test Item 2",
+            "description": "This is another test item",
+            "stockCount": 3
+          }
+        ]
+      },
+      "request": {
+        "method": "GET",
+        "path": "/order-service/v1/items",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "accept": "*/*",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": "",
+        "query": ""
+      }
+    },
+    {
+      "description": "POST /order-service/v1/purchase returns status 200",
+      "response": {
+        "status": 200
+      },
+      "request": {
+        "method": "POST",
+        "path": "/order-service/v1/purchase",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "content-length": "25",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "content-type": "application/json",
+          "accept": "*/*",
+          "origin": "http://localhost:5173",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": {
+          "itemId": 1,
+          "quantity": 3
+        },
+        "query": ""
+      }
+    },
+    {
+      "description": "POST /order-service/v1/purchase returns status 500",
+      "response": {
+        "status": 500
+      },
+      "request": {
+        "method": "POST",
+        "path": "/order-service/v1/purchase",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "content-length": "25",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "content-type": "application/json",
+          "accept": "*/*",
+          "origin": "http://localhost:5173",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": {
+          "itemId": 1,
+          "quantity": 1
+        },
+        "query": ""
+      }
+    },
+    {
+      "description": "GET /order-service/v1/items returns status 200 (disables buy button when stock is 0)",
+      "response": {
+        "status": 200,
+        "body": [
+          {
+            "id": 1,
+            "name": "Out of Stock Item",
+            "description": "This item is out of stock",
+            "stockCount": 0
+          }
+        ]
+      },
+      "request": {
+        "method": "GET",
+        "path": "/order-service/v1/items",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "accept": "*/*",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": "",
+        "query": ""
+      }
+    }
+  ]
+}

--- a/src/App.cy.tsx
+++ b/src/App.cy.tsx
@@ -5,7 +5,7 @@ import App from './App'
 
 describe('App.tsx', () => {
   beforeEach(() => {
-    cy.intercept('GET', `order-service/v1/items`, {
+    cy.pactIntercept('GET', `order-service/v1/items`, {
       statusCode: 200,
       body: [
         {
@@ -45,7 +45,7 @@ describe('App.tsx', () => {
   })
 
   it('allows selecting quantity and buying items', () => {
-    cy.intercept('POST', `order-service/v1/purchase`, {
+    cy.pactIntercept('POST', `order-service/v1/purchase`, {
       statusCode: 200,
     }).as('purchase')
 
@@ -67,7 +67,7 @@ describe('App.tsx', () => {
   })
 
   it('handles purchase errors correctly', () => {
-    cy.intercept('POST', `order-service/v1/purchase`, {
+    cy.pactIntercept('POST', `order-service/v1/purchase`, {
       statusCode: 500,
     }).as('purchaseError')
 
@@ -80,7 +80,7 @@ describe('App.tsx', () => {
   })
 
   it('disables buy button when stock is 0', () => {
-    cy.intercept('GET', `order-service/v1/items`, {
+    cy.pactIntercept('GET', `order-service/v1/items`, {
       statusCode: 200,
       body: [
         {

--- a/tsconfig.app.tsbuildinfo
+++ b/tsconfig.app.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.cy.tsx","./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts","./cypress/support/commands.ts","./cypress/support/component.ts"],"version":"5.6.3"}

--- a/tsconfig.app.tsbuildinfo
+++ b/tsconfig.app.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/app.cy.tsx","./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts"],"version":"5.6.3"}
+{"root":["./src/app.cy.tsx","./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts","./cypress/support/commands.ts","./cypress/support/component.ts"],"version":"5.6.3"}


### PR DESCRIPTION
# 🔗 Integrate Pact Consumer Contract Testing

## Summary

This PR integrates [pact-js-mock](https://github.com/pact-foundation/pact-js-mock) to automatically generate Pact consumer contracts from existing Cypress test mocks. This enables contract testing with the `order-service` provider without requiring any changes to test logic or assertions.

## What Changed

### Dependencies
- ✅ Added `pact-js-mock@^1.0.1` as a dev dependency

### Configuration
- ✅ Created `pact.config.json` with consumer name `shop-frontend` and Pact version 2.0.0
- ✅ Updated `cypress.config.ts` to register the Pact plugin for automatic lifecycle management
- ✅ Updated `cypress/support/component.ts` to import pact-js-mock Cypress support

### Test Files
- ✅ Replaced all `cy.intercept()` calls with `cy.pactIntercept()` in `src/App.cy.tsx` (4 intercepts)
  - All existing test logic, assertions, and aliases remain **unchanged**
  - Tests continue to work exactly as before

### CI/CD
- ✅ Updated `.github/workflows/main.yml` to publish contracts to Pact Broker after successful tests
  - Only publishes on pushes to `main` branch
  - Uses GitHub secrets for authentication

## Generated Contracts

After running tests, Pact contracts are automatically generated in `./pacts/`:

- **File**: `shop-frontend-order-service.json`
- **Consumer**: `shop-frontend`
- **Provider**: `order-service` (automatically inferred from URLs)
- **Interactions**: 4 interactions captured:
  1. `GET /order-service/v1/items` → 200 (with items list)
  2. `POST /order-service/v1/purchase` → 200 (successful purchase)
  3. `POST /order-service/v1/purchase` → 500 (error case)
  4. `GET /order-service/v1/items` → 200 (out of stock item)

## Benefits

- 🎯 **Zero Breaking Changes**: All existing tests work exactly as before
- 🤖 **Automatic Contract Generation**: Contracts are generated as a side effect of running tests
- 🔄 **Provider Inference**: Provider names are automatically inferred from URLs
- 📦 **No Boilerplate**: No need to manually create Pact instances or manage contract files
- 🚀 **CI/CD Ready**: Contracts are automatically published to Pact Broker on main branch

## Testing

✅ **Build**: Passes successfully  
✅ **Tests**: All 5 Cypress component tests pass  
✅ **Pact Generation**: Contracts generated correctly with all 4 interactions  
✅ **Consumer/Provider Names**: Correctly identified

### Test Results
```
✓ displays the application title
✓ displays items with their details
✓ allows selecting quantity and buying items
✓ handles purchase errors correctly
✓ disables buy button when stock is 0

5 passing (2s)
```

## Required Configuration

### GitHub Secrets (Required for CI/CD)

Before merging, add the following secrets to the repository:

1. Go to **Settings → Secrets and variables → Actions**
2. Add the following secrets:
   - `PACT_BROKER_BASE_URL`: Your Pact Broker URL (e.g., `https://your-broker.pactflow.io`)
   - `PACT_BROKER_TOKEN`: Your Pact Broker authentication token

**Note**: The CI/CD step will fail gracefully if secrets are not configured (using `continue-on-error: true`), so the PR can be merged without blocking, but contracts won't be published until secrets are added.

## Migration Details

### Before
```typescript
cy.intercept('GET', `order-service/v1/items`, {
  statusCode: 200,
  body: [...],
}).as('getItems')
```

### After
```typescript
cy.pactIntercept('GET', `order-service/v1/items`, {
  statusCode: 200,
  body: [...],
}).as('getItems')
```

**That's it!** The API is identical to `cy.intercept()`, so the migration was a simple find-and-replace.

## Next Steps

1. ✅ **Merge this PR** (after review)
2. ⚙️ **Configure GitHub Secrets** (see above)
3. 📊 **Verify in Pact Broker**: After the next push to `main`, verify contracts appear in the broker
4. 🔗 **Provider Integration**: The `order-service` team can now verify these contracts against their implementation

## Documentation

See `PACT_MIGRATION_SUMMARY.md` for:
- Customization options (descriptions, provider states, matching rules)
- Manual publishing commands
- Troubleshooting tips
- Advanced configuration

## Breaking Changes

**None** - This is a non-breaking change. All existing tests continue to work exactly as before.

## Related

- [pact-js-mock documentation](https://github.com/pact-foundation/pact-js-mock)
- [Pact documentation](https://docs.pact.io/)
- [Pact Broker documentation](https://docs.pact.io/pact_broker)

