### PR TITLE
Migrate to pact-js-mock for Contract Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,12 @@ jobs:
       
       - name: Run tests
         run: npm test
+
+      - name: Publish Pact contracts to Pact Broker
+        if: always()
+        run: |
+          npx @pact-foundation/pact-cli@latest broker publish ./pacts \
+            --consumer-app-version ${{ github.sha }} \
+            --branch ${{ github.ref_name }} \
+            --broker-base-url ${{ secrets.PACT_BROKER_BASE_URL }} \
+            --broker-token ${{ secrets.PACT_BROKER_TOKEN }}

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,144 @@
+# Migrate to pact-js-mock for Contract Testing
+
+## Summary
+
+This PR migrates the existing Cypress test mocks to generate Pact consumer contracts using `pact-js-mock`. The migration enables automatic contract generation from existing test mocks without requiring additional test code or maintaining duplicate mock definitions.
+
+## What Changed
+
+### Files Modified
+
+1. **`package.json`**
+   - Added `pact-js-mock` as a dev dependency
+
+2. **`cypress.config.ts`**
+   - Registered the Pact plugin via `setupNodeEvents` hook
+   - Imported `pactPlugin` from `pact-js-mock/lib/cypress/plugin`
+
+3. **`cypress/support/component.ts`**
+   - Added import for `pact-js-mock/lib/cypress` to register `cy.pactIntercept()` command and lifecycle hooks
+
+4. **`src/App.cy.tsx`**
+   - Replaced all `cy.intercept()` calls with `cy.pactIntercept()` (4 occurrences)
+   - All existing test logic, assertions, and aliases remain unchanged
+   - Tests continue to work exactly as before, now with automatic contract generation
+
+5. **`.github/workflows/main.yml`**
+   - Added step to publish Pact contracts to Pact Broker after tests complete
+   - Contracts are published on all branches (feature branches, PRs, and main)
+   - Uses Git commit SHA for contract versioning
+   - Uses branch name for branch tagging in Pact Broker
+
+### Files Created
+
+1. **`pact.config.json`**
+   - Configuration file specifying consumer name (`shop-frontend`), pact version (`2.0.0`), and output directory (`./pacts`)
+
+2. **`pacts/shop-frontend-order-service.json`**
+   - Generated Pact contract file containing all API interactions from tests
+   - Includes 4 interactions:
+     - GET `/order-service/v1/items` (successful response with items)
+     - POST `/order-service/v1/purchase` (successful purchase)
+     - POST `/order-service/v1/purchase` (error response - 500)
+     - GET `/order-service/v1/items` (out of stock scenario)
+
+## How It Works
+
+- **Automatic Contract Generation**: Pact contracts are generated automatically as a side effect of running tests
+- **Zero Boilerplate**: No need to manually create Pact instances or wrap resolvers - just use `cy.pactIntercept()` instead of `cy.intercept()`
+- **Provider Name Inference**: Provider names are automatically inferred from URLs (e.g., `order-service/v1/items` → provider: "order-service")
+- **Lifecycle Management**: The Pact plugin automatically handles contract lifecycle (cleanup, reload, write) via Cypress hooks
+- **Backward Compatible**: All existing tests continue to work unchanged - the API is identical to `cy.intercept()`
+
+## Testing
+
+✅ **All tests pass** (5/5 passing)
+- No regressions introduced
+- All existing test assertions continue to work
+- Test execution time unchanged (~2 seconds)
+
+✅ **Pact contracts generated successfully**
+- Contract file: `pacts/shop-frontend-order-service.json`
+- Consumer: `shop-frontend`
+- Provider: `order-service`
+- All 4 interactions captured correctly
+
+✅ **Build verification**
+- TypeScript compilation succeeds
+- Vite build completes successfully
+- No breaking changes introduced
+
+## Next Steps
+
+### Required: Configure Pact Broker
+
+To enable contract publishing in CI/CD, configure the following GitHub Secrets:
+
+1. **`PACT_BROKER_BASE_URL`**: The base URL of your Pact Broker instance
+   - Example: `https://pact-broker.example.com`
+   - Or: `https://your-org.pact.dius.com.au`
+
+2. **`PACT_BROKER_TOKEN`**: Authentication token for Pact Broker
+   - Generate this from your Pact Broker UI or via API
+   - Ensure the token has publish permissions
+
+### Optional: Enhance Contracts
+
+1. **Add Interaction Descriptions**: Customize interaction descriptions for better readability:
+   ```typescript
+   cy.pactIntercept('GET', '/order-service/v1/items', response, {
+     description: 'get all available items',
+   })
+   ```
+
+2. **Add Provider States**: Specify provider states for better contract clarity:
+   ```typescript
+   cy.pactIntercept('GET', '/order-service/v1/items', response, {
+     providerState: 'items exist in inventory',
+   })
+   ```
+
+3. **Add Matching Rules**: For dynamic data, add matching rules (Pact V3/V4):
+   ```typescript
+   cy.pactIntercept('GET', '/order-service/v1/items', response, {
+     matchingRules: {
+       body: {
+         '$.id': { matcher: { type: 'integer' } },
+       },
+     },
+   })
+   ```
+
+4. **Configure Header Filtering**: Customize which headers are included/excluded in contracts via `pact.config.json` or plugin configuration
+
+### Optional: Add can-i-deploy Check
+
+Consider adding a `can-i-deploy` check before deployment (typically on main/master or release branches):
+
+```yaml
+- name: Check if can deploy
+  run: |
+    npx @pact-foundation/pact-cli@latest broker can-i-deploy \
+      --pacticipant shop-frontend \
+      --version ${{ github.sha }} \
+      --broker-base-url ${{ secrets.PACT_BROKER_BASE_URL }} \
+      --broker-token ${{ secrets.PACT_BROKER_TOKEN }}
+```
+
+## Breaking Changes
+
+**None** - All existing tests continue to work unchanged. The migration is fully backward compatible.
+
+## Configuration
+
+- **Consumer Name**: `shop-frontend` (from `pact.config.json`, defaults to `package.json` name)
+- **Pact Version**: `2.0.0` (configurable in `pact.config.json`)
+- **Output Directory**: `./pacts` (configurable in `pact.config.json`)
+- **Provider Name**: Automatically inferred from URL patterns (`order-service`)
+
+## Documentation
+
+- [pact-js-mock GitHub Repository](https://github.com/ludorival/pact-js-mock)
+- [Pact Documentation](https://docs.pact.io/)
+- [Pact Broker Documentation](https://docs.pact.io/pact_broker)
+

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "cypress";
+import pactPlugin from "pact-js-mock/lib/cypress/plugin";
 
 export default defineConfig({
   component: {
     devServer: {
       framework: "react",
       bundler: "vite",
+    },
+    setupNodeEvents(on, config) {
+      return pactPlugin(on, config);
     },
   },
 });

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -16,5 +16,8 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
+// Import pact-js-mock Cypress support
+import 'pact-js-mock/lib/cypress'
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.11.0",
+        "pact-js-mock": "^1.0.1",
         "prettier": "^3.3.3",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.11.0",
@@ -4652,6 +4653,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pact-js-mock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pact-js-mock/-/pact-js-mock-1.0.1.tgz",
+      "integrity": "sha512-qgsHpULX4dRpdk+o1YmIIP2PuRVxwWWWU7vq3oAVJOammrT5b9rFHL4Ev/Feh6UOML3PEF4RF/DiroEqBFvY7w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/parent-module": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
+    "pact-js-mock": "^1.0.1",
     "prettier": "^3.3.3",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",

--- a/pact.config.json
+++ b/pact.config.json
@@ -1,0 +1,6 @@
+{
+  "consumerName": "shop-frontend",
+  "pactVersion": "2.0.0",
+  "outputDir": "./pacts"
+}
+

--- a/pacts/shop-frontend-order-service.json
+++ b/pacts/shop-frontend-order-service.json
@@ -1,0 +1,161 @@
+{
+  "consumer": {
+    "name": "shop-frontend"
+  },
+  "provider": {
+    "name": "order-service"
+  },
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    },
+    "client": {
+      "name": "pact-js-mock",
+      "version": "1.0.1"
+    }
+  },
+  "interactions": [
+    {
+      "description": "GET /order-service/v1/items returns status 200",
+      "response": {
+        "status": 200,
+        "body": [
+          {
+            "id": 1,
+            "name": "Test Item 1",
+            "description": "This is a test item",
+            "stockCount": 5
+          },
+          {
+            "id": 2,
+            "name": "Test Item 2",
+            "description": "This is another test item",
+            "stockCount": 3
+          }
+        ]
+      },
+      "request": {
+        "method": "GET",
+        "path": "/order-service/v1/items",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "accept": "*/*",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": "",
+        "query": ""
+      }
+    },
+    {
+      "description": "POST /order-service/v1/purchase returns status 200",
+      "response": {
+        "status": 200
+      },
+      "request": {
+        "method": "POST",
+        "path": "/order-service/v1/purchase",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "content-length": "25",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "content-type": "application/json",
+          "accept": "*/*",
+          "origin": "http://localhost:5173",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": {
+          "itemId": 1,
+          "quantity": 3
+        },
+        "query": ""
+      }
+    },
+    {
+      "description": "POST /order-service/v1/purchase returns status 500",
+      "response": {
+        "status": 500
+      },
+      "request": {
+        "method": "POST",
+        "path": "/order-service/v1/purchase",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "content-length": "25",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "content-type": "application/json",
+          "accept": "*/*",
+          "origin": "http://localhost:5173",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": {
+          "itemId": 1,
+          "quantity": 1
+        },
+        "query": ""
+      }
+    },
+    {
+      "description": "GET /order-service/v1/items returns status 200 (disables buy button when stock is 0)",
+      "response": {
+        "status": 200,
+        "body": [
+          {
+            "id": 1,
+            "name": "Out of Stock Item",
+            "description": "This item is out of stock",
+            "stockCount": 0
+          }
+        ]
+      },
+      "request": {
+        "method": "GET",
+        "path": "/order-service/v1/items",
+        "headers": {
+          "host": "localhost:5173",
+          "proxy-connection": "keep-alive",
+          "sec-ch-ua": "\"Not=A?Brand\";v=\"99\", \"Chromium\";v=\"118\"",
+          "sec-ch-ua-mobile": "?0",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.17.0 Chrome/118.0.5993.159 Electron/27.3.10 Safari/537.36",
+          "sec-ch-ua-platform": "\"macOS\"",
+          "accept": "*/*",
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          "referer": "http://localhost:5173/__cypress/iframes/index.html?specPath=/Users/manou/workspaces/shop-pact-mock-frontend/src/App.cy.tsx",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "fr"
+        },
+        "body": "",
+        "query": ""
+      }
+    }
+  ]
+}

--- a/src/App.cy.tsx
+++ b/src/App.cy.tsx
@@ -5,7 +5,7 @@ import App from './App'
 
 describe('App.tsx', () => {
   beforeEach(() => {
-    cy.intercept('GET', `order-service/v1/items`, {
+    cy.pactIntercept('GET', `order-service/v1/items`, {
       statusCode: 200,
       body: [
         {
@@ -45,7 +45,7 @@ describe('App.tsx', () => {
   })
 
   it('allows selecting quantity and buying items', () => {
-    cy.intercept('POST', `order-service/v1/purchase`, {
+    cy.pactIntercept('POST', `order-service/v1/purchase`, {
       statusCode: 200,
     }).as('purchase')
 
@@ -67,7 +67,7 @@ describe('App.tsx', () => {
   })
 
   it('handles purchase errors correctly', () => {
-    cy.intercept('POST', `order-service/v1/purchase`, {
+    cy.pactIntercept('POST', `order-service/v1/purchase`, {
       statusCode: 500,
     }).as('purchaseError')
 
@@ -80,7 +80,7 @@ describe('App.tsx', () => {
   })
 
   it('disables buy button when stock is 0', () => {
-    cy.intercept('GET', `order-service/v1/items`, {
+    cy.pactIntercept('GET', `order-service/v1/items`, {
       statusCode: 200,
       body: [
         {

--- a/tsconfig.app.tsbuildinfo
+++ b/tsconfig.app.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/app.cy.tsx","./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts"],"version":"5.6.3"}
+{"root":["./src/app.cy.tsx","./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts","./cypress/support/commands.ts","./cypress/support/component.ts"],"version":"5.6.3"}


### PR DESCRIPTION
# Migrate to pact-js-mock for Contract Testing

## Summary

This PR migrates the existing Cypress test mocks to generate Pact consumer contracts using `pact-js-mock`. The migration enables automatic contract generation from existing test mocks without requiring additional test code or maintaining duplicate mock definitions.

## What Changed

### Files Modified

1. **`package.json`**
   - Added `pact-js-mock` as a dev dependency

2. **`cypress.config.ts`**
   - Registered the Pact plugin via `setupNodeEvents` hook
   - Imported `pactPlugin` from `pact-js-mock/lib/cypress/plugin`

3. **`cypress/support/component.ts`**
   - Added import for `pact-js-mock/lib/cypress` to register `cy.pactIntercept()` command and lifecycle hooks

4. **`src/App.cy.tsx`**
   - Replaced all `cy.intercept()` calls with `cy.pactIntercept()` (4 occurrences)
   - All existing test logic, assertions, and aliases remain unchanged
   - Tests continue to work exactly as before, now with automatic contract generation

5. **`.github/workflows/main.yml`**
   - Added step to publish Pact contracts to Pact Broker after tests complete
   - Contracts are published on all branches (feature branches, PRs, and main)
   - Uses Git commit SHA for contract versioning
   - Uses branch name for branch tagging in Pact Broker

### Files Created

1. **`pact.config.json`**
   - Configuration file specifying consumer name (`shop-frontend`), pact version (`2.0.0`), and output directory (`./pacts`)

2. **`pacts/shop-frontend-order-service.json`**
   - Generated Pact contract file containing all API interactions from tests
   - Includes 4 interactions:
     - GET `/order-service/v1/items` (successful response with items)
     - POST `/order-service/v1/purchase` (successful purchase)
     - POST `/order-service/v1/purchase` (error response - 500)
     - GET `/order-service/v1/items` (out of stock scenario)

## How It Works

- **Automatic Contract Generation**: Pact contracts are generated automatically as a side effect of running tests
- **Zero Boilerplate**: No need to manually create Pact instances or wrap resolvers - just use `cy.pactIntercept()` instead of `cy.intercept()`
- **Provider Name Inference**: Provider names are automatically inferred from URLs (e.g., `order-service/v1/items` → provider: "order-service")
- **Lifecycle Management**: The Pact plugin automatically handles contract lifecycle (cleanup, reload, write) via Cypress hooks
- **Backward Compatible**: All existing tests continue to work unchanged - the API is identical to `cy.intercept()`

## Testing

✅ **All tests pass** (5/5 passing)
- No regressions introduced
- All existing test assertions continue to work
- Test execution time unchanged (~2 seconds)

✅ **Pact contracts generated successfully**
- Contract file: `pacts/shop-frontend-order-service.json`
- Consumer: `shop-frontend`
- Provider: `order-service`
- All 4 interactions captured correctly

✅ **Build verification**
- TypeScript compilation succeeds
- Vite build completes successfully
- No breaking changes introduced

## Next Steps

### Required: Configure Pact Broker

To enable contract publishing in CI/CD, configure the following GitHub Secrets:

1. **`PACT_BROKER_BASE_URL`**: The base URL of your Pact Broker instance
   - Example: `https://pact-broker.example.com`
   - Or: `https://your-org.pact.dius.com.au`

2. **`PACT_BROKER_TOKEN`**: Authentication token for Pact Broker
   - Generate this from your Pact Broker UI or via API
   - Ensure the token has publish permissions

### Optional: Enhance Contracts

1. **Add Interaction Descriptions**: Customize interaction descriptions for better readability:
   ```typescript
   cy.pactIntercept('GET', '/order-service/v1/items', response, {
     description: 'get all available items',
   })
   ```

2. **Add Provider States**: Specify provider states for better contract clarity:
   ```typescript
   cy.pactIntercept('GET', '/order-service/v1/items', response, {
     providerState: 'items exist in inventory',
   })
   ```

3. **Add Matching Rules**: For dynamic data, add matching rules (Pact V3/V4):
   ```typescript
   cy.pactIntercept('GET', '/order-service/v1/items', response, {
     matchingRules: {
       body: {
         '$.id': { matcher: { type: 'integer' } },
       },
     },
   })
   ```

4. **Configure Header Filtering**: Customize which headers are included/excluded in contracts via `pact.config.json` or plugin configuration

### Optional: Add can-i-deploy Check

Consider adding a `can-i-deploy` check before deployment (typically on main/master or release branches):

```yaml
- name: Check if can deploy
  run: |
    npx @pact-foundation/pact-cli@latest broker can-i-deploy \
      --pacticipant shop-frontend \
      --version ${{ github.sha }} \
      --broker-base-url ${{ secrets.PACT_BROKER_BASE_URL }} \
      --broker-token ${{ secrets.PACT_BROKER_TOKEN }}
```

## Breaking Changes

**None** - All existing tests continue to work unchanged. The migration is fully backward compatible.

## Configuration

- **Consumer Name**: `shop-frontend` (from `pact.config.json`, defaults to `package.json` name)
- **Pact Version**: `2.0.0` (configurable in `pact.config.json`)
- **Output Directory**: `./pacts` (configurable in `pact.config.json`)
- **Provider Name**: Automatically inferred from URL patterns (`order-service`)

## Documentation

- [pact-js-mock GitHub Repository](https://github.com/ludorival/pact-js-mock)
- [Pact Documentation](https://docs.pact.io/)
- [Pact Broker Documentation](https://docs.pact.io/pact_broker)

